### PR TITLE
Fix README path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone [your-repository-url]
 
 2. Navigate to the project directory:
 ```bash
-cd portfolio
+cd portfolio-website
 ```
 
 3. Open `index.html` in your web browser to view the website.


### PR DESCRIPTION
## Summary
- fix the directory name in the README install instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e05e31b48832c853e31a153b9c503