### PR TITLE
Add Jest setup and test for particle canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "portfolio-website",
+  "version": "1.0.0",
+  "description": "A modern, interactive portfolio website showcasing my projects and professional journey. Built with a focus on user experience, animations, and responsive design.",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.4",
+    "jsdom": "^26.1.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/initParticlesBackground.test.js
+++ b/tests/initParticlesBackground.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+const { JSDOM } = require('jsdom');
+
+describe('initParticlesBackground', () => {
+  test('adds a particles canvas to the document body', () => {
+    const html = '<!doctype html><html><body></body></html>';
+    const dom = new JSDOM(html, { runScripts: 'dangerously' });
+    dom.window.requestAnimationFrame = () => {};
+    dom.window.HTMLCanvasElement.prototype.getContext = () => ({
+      clearRect: jest.fn(),
+      beginPath: jest.fn(),
+      arc: jest.fn(),
+      fill: jest.fn(),
+      stroke: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn()
+    });
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../script.js'), 'utf8');
+
+    // Execute the script inside the JSDOM window so functions are attached to it
+    dom.window.eval(scriptContent);
+
+    // Call the function to initialize the particles background
+    dom.window.initParticlesBackground();
+
+    const canvas = dom.window.document.getElementById('particles-canvas');
+    expect(canvas).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest configuration in package.json
- ignore node_modules and lockfile
- add initParticlesBackground JSDOM test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e05ec5e40832caa64c140eb6d4521