### PR TITLE
Fix mailto link in contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
                             <p>I'm always open for collaborations, freelance gigs, or just a tech chat. Drop me a message!</p>
                             <p><strong>Email:</strong>f20212756@pilani.bits-pilani.ac.in</p>
                             <p><strong>Phone:</strong> +91-9458827686</p>
-                            <a href="f20212756@pilani.bits-pilani.ac.in" class="btn mt-auto align-self-center">Say Hello</a>
+                            <a href="mailto:f20212756@pilani.bits-pilani.ac.in" class="btn mt-auto align-self-center">Say Hello</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- fix contact section email anchor to use `mailto:` scheme

## Testing
- `sed -n '200,206p' index.html`

------
https://chatgpt.com/codex/tasks/task_e_687e05d2c988832c966bd8c594e73eb1