### PR TITLE
Add Phaser-based exploration space game

### DIFF
--- a/phaser-space-explorer/game.js
+++ b/phaser-space-explorer/game.js
@@ -1,0 +1,32 @@
+// Deep Space Explorer in Phaser 3
+// Exploration-first vertical space game with rare combat encounters.
+// Performance knobs:
+//   window.GFX = { bloom: true, vignette: true, particles: 1.0, encounterPeriod: 15000 };
+// Tuning these at runtime adjusts visual quality and encounter density.
+// TODO: power-ups, boss sectors, codex/galactopedia UI, save to localStorage
+
+window.GFX = { bloom: true, vignette: true, particles: 1.0, encounterPeriod: 15000 };
+
+import BootScene from './src/BootScene.js';
+import TitleScene from './src/TitleScene.js';
+import PlayScene from './src/PlayScene.js';
+import HUDScene from './src/HUDScene.js';
+
+const config = {
+  type: Phaser.WEBGL,
+  width: window.innerWidth,
+  height: window.innerHeight,
+  parent: document.body,
+  scene: [BootScene, TitleScene, PlayScene, HUDScene],
+  physics: { default: 'arcade', arcade: { gravity: { y: 0 }, debug: false } },
+  audio: { disableWebAudio: false }
+};
+
+const game = new Phaser.Game(config);
+
+window.addEventListener('resize', () => {
+  game.scale.resize(window.innerWidth, window.innerHeight);
+});
+
+// Expose for console tweaking
+window.__game = game;

--- a/phaser-space-explorer/index.html
+++ b/phaser-space-explorer/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deep Space Explorer - Phaser</title>
+  <!-- Phaser 3 CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.js"></script>
+  <style>
+    body,html{margin:0;padding:0;overflow:hidden;background:#05070d;color:#e5e7eb;font-family:sans-serif;}
+    #hud{position:absolute;top:8px;left:8px;right:8px;display:flex;justify-content:space-between;pointer-events:none;z-index:10;}
+    .pill{background:rgba(10,16,30,.65);border:1px solid rgba(224,194,159,.22);border-radius:999px;padding:4px 10px;margin:0 4px;font-weight:600;}
+    #help{position:absolute;bottom:8px;right:8px;font-size:12px;background:rgba(10,16,30,.65);border:1px solid rgba(224,194,159,.22);padding:4px 8px;border-radius:8px;pointer-events:none;z-index:10;}
+    /* Photo mode hides HUD by toggling class */
+    .hidden{display:none;}
+  </style>
+</head>
+<body>
+  <div id="hud">
+    <div class="pill">Discoveries: <span id="disc">0</span></div>
+    <div class="pill">Hull: <span id="hull">3</span></div>
+    <div class="pill">Sector: <span id="sector">-</span></div>
+  </div>
+  <div id="help">Move: WASD / Left Stick · Shoot: Space/A · Scan: E/X · Shield: Shift/LB · Pause: Esc/Start</div>
+  <!-- Game code -->
+  <script type="module" src="game.js"></script>
+</body>
+</html>

--- a/phaser-space-explorer/src/BootScene.js
+++ b/phaser-space-explorer/src/BootScene.js
@@ -1,0 +1,36 @@
+import BloomPipeline from './pipelines/BloomPipeline.js';
+import VignettePipeline from './pipelines/VignettePipeline.js';
+
+export default class BootScene extends Phaser.Scene {
+  constructor(){ super('Boot'); }
+  preload(){
+    // Generate tiny textures procedurally to keep repo asset-free
+    const g = this.add.graphics();
+    // star
+    g.fillStyle(0xffffff,1).fillCircle(4,4,4);
+    g.generateTexture('star',8,8); g.clear();
+    // player
+    g.fillStyle(0x20b2ae,1).fillPolygon([0,0, 32,16, 0,32]);
+    g.generateTexture('player',32,32); g.clear();
+    // bullet
+    g.fillStyle(0xa4b1ff,1).fillRect(0,0,4,12);
+    g.generateTexture('bullet',4,12); g.clear();
+    // enemy
+    g.fillStyle(0xf87171,1).fillTriangle(0,0, 28,14, 0,28);
+    g.generateTexture('enemy',28,28); g.clear();
+    // planet
+    g.fillStyle(0x7788ff,1).fillCircle(64,64,64);
+    g.lineStyle(4,0xffffff,0.4).strokeCircle(64,64,68);
+    g.generateTexture('planet',128,128); g.clear();
+    // ring
+    g.lineStyle(3,0xffffff,0.6).strokeCircle(64,64,64);
+    g.generateTexture('ring',128,128); g.clear();
+  }
+  create(){
+    // Register pipelines
+    const bloom = this.renderer.pipelines.addPostPipeline('BloomPipeline', new BloomPipeline(this.game));
+    const vignette = this.renderer.pipelines.addPostPipeline('VignettePipeline', new VignettePipeline(this.game));
+    this.game.registry.set('pipelines', { bloom, vignette });
+    this.scene.start('Title');
+  }
+}

--- a/phaser-space-explorer/src/EncounterDirector.js
+++ b/phaser-space-explorer/src/EncounterDirector.js
@@ -1,0 +1,28 @@
+// Manages spawning small enemy formations on a timer
+export default class EncounterDirector {
+  constructor(scene){
+    this.scene = scene;
+    this.timer = 0;
+  }
+  update(time, delta){
+    this.timer += delta;
+    const period = window.GFX.encounterPeriod || 15000;
+    if(this.timer > period){
+      this.timer = 0;
+      this.spawn();
+    }
+  }
+  spawn(){
+    const width = this.scene.scale.width;
+    const type = Phaser.Math.RND.weightedPick(['scout','tank','pulsar']);
+    const group = this.scene.add.group();
+    for(let i=0;i<3;i++){
+      const enemy = this.scene.physics.add.sprite(width/2 + (i-1)*40, -50, 'enemy');
+      enemy.setData('type', type);
+      enemy.setVelocity(0, 40 + i*10);
+      enemy.setData('hp', type==='tank'?4:2);
+      group.add(enemy);
+    }
+    this.scene.enemies.addMultiple(group.getChildren());
+  }
+}

--- a/phaser-space-explorer/src/HUDScene.js
+++ b/phaser-space-explorer/src/HUDScene.js
@@ -1,0 +1,21 @@
+export default class HUDScene extends Phaser.Scene {
+  constructor(){ super({ key:'HUD', active:false }); }
+  create(){
+    this.discEl = document.getElementById('disc');
+    this.hullEl = document.getElementById('hull');
+    this.secEl = document.getElementById('sector');
+    this.help = document.getElementById('help');
+
+    // Listen to events from Play scene
+    const play = this.scene.get('Play');
+    play.events.on('updateHud', data => {
+      if(data.discoveries!==undefined) this.discEl.textContent = data.discoveries;
+      if(data.hull!==undefined) this.hullEl.textContent = data.hull;
+      if(data.sector!==undefined) this.secEl.textContent = data.sector;
+    });
+    play.events.on('photo', on => {
+      document.getElementById('hud').classList.toggle('hidden', on);
+      this.help.classList.toggle('hidden', on);
+    });
+  }
+}

--- a/phaser-space-explorer/src/PlayScene.js
+++ b/phaser-space-explorer/src/PlayScene.js
@@ -1,0 +1,182 @@
+import SectorFactory from './SectorFactory.js';
+import EncounterDirector from './EncounterDirector.js';
+
+export default class PlayScene extends Phaser.Scene {
+  constructor(){ super('Play'); }
+  create(){
+    // Camera post effects
+    const pipes = this.game.registry.get('pipelines');
+    if(window.GFX.bloom) this.cameras.main.setPostPipeline(pipes.bloom);
+    if(window.GFX.vignette) this.cameras.main.setPostPipeline(pipes.vignette);
+
+    // world
+    this.player = this.physics.add.sprite(this.scale.width/2, this.scale.height*0.7, 'player');
+    this.player.setDamping(true).setDrag(0.9).setMaxVelocity(200);
+    this.player.setData({ hull:3, shield:false, discoveries:0 });
+
+    // bullets / enemies
+    this.bullets = this.physics.add.group();
+    this.enemies = this.physics.add.group();
+
+    // sector
+    this.seed = Date.now() & 0xffff;
+    this.loadSector(this.seed);
+
+    // scanning
+    this.scanRing = this.add.circle(0,0,10,0x20b2ae,0.3).setVisible(false);
+
+    // encounter director
+    this.director = new EncounterDirector(this);
+
+    // input
+    this.cursors = this.input.keyboard.createCursorKeys();
+    this.keys = this.input.keyboard.addKeys('W,A,S,D,SPACE,E,SHIFT,ESC,O');
+    // gamepad
+    this.pad = null;
+    this.input.gamepad.on('connected', pad => { this.pad = pad; });
+    this.input.gamepad.on('disconnected', pad=>{ if(this.pad && pad.index===this.pad.index) this.pad=null; });
+
+    // audio
+    this.soundCtx = this.game.sound.context;
+    this.master = this.soundCtx.createGain();
+    this.master.connect(this.soundCtx.destination);
+    this.sfx = this.soundCtx.createGain(); this.sfx.connect(this.master);
+
+    // collisions
+    this.physics.add.overlap(this.bullets, this.enemies, this.hitEnemy, null, this);
+    this.physics.add.overlap(this.player, this.enemies, this.playerHit, null, this);
+
+    this.events.emit('updateHud', { discoveries:0, hull:3, sector:this.sector.name });
+  }
+
+  loadSector(seed){
+    if(this.starGroup){ this.starGroup.destroy(true); }
+    const sector = SectorFactory(seed);
+    this.sector = sector;
+    // starfield layers using particle emitters
+    this.starGroup = this.add.particles('star');
+    for(let i=0;i<sector.stars.length;i++){
+      this.starGroup.createEmitter({
+        x: { min:0, max:this.scale.width },
+        y: { min:0, max:this.scale.height },
+        lifespan: 60000,
+        quantity: Math.floor(80 * window.GFX.particles),
+        frequency: -1,
+        speedY: 20*(i+1),
+        scale: 0.1 + i*0.2,
+        blendMode: 'ADD'
+      });
+    }
+    // planets
+    this.planets = this.add.group();
+    sector.planets.forEach(p=>{
+      const planet = this.add.sprite(p.x, p.y, 'planet').setScale(p.scale).setTint(p.tint);
+      const ring = this.add.sprite(p.x, p.y, 'ring').setScale(p.scale*1.2).setTint(0xffffff).setAlpha(0.4);
+      ring.rotation = Math.random();
+      this.planets.add(planet); this.planets.add(ring);
+    });
+    // nebulae
+    this.nebulae = this.add.group();
+    sector.nebulae.forEach(n=>{
+      const nb = this.add.rectangle(n.x, n.y, 400, 300, n.color, n.alpha);
+      nb.setBlendMode(Phaser.BlendModes.ADD);
+      this.nebulae.add(nb);
+    });
+    // TODO: galaxies, belts, stations, anomalies, dark-matter fields etc.
+  }
+
+  fire(){
+    const bullet = this.bullets.get(this.player.x, this.player.y-20, 'bullet');
+    if(!bullet){ return; }
+    bullet.setActive(true).setVisible(true);
+    bullet.body.reset(this.player.x, this.player.y-20);
+    bullet.setVelocity(0,-300);
+    // audio ping
+    const osc = this.soundCtx.createOscillator(); osc.frequency.value=440; osc.connect(this.sfx); osc.start(); osc.stop(this.soundCtx.currentTime+0.1);
+  }
+
+  scan(){
+    this.scanRing.setVisible(true).setPosition(this.player.x, this.player.y).setRadius(10);
+    this.tweens.add({ targets:this.scanRing, radius:200, alpha:0, duration:500, onComplete:()=>{ this.scanRing.setVisible(false).setAlpha(0.3); } });
+    // simple proximity check
+    let found=false;
+    this.planets.children.iterate(p=>{ if(Phaser.Math.Distance.Between(this.player.x,this.player.y,p.x,p.y)<150){ found=true; }});
+    if(found){
+      this.player.data.values.discoveries++;
+      this.events.emit('updateHud',{ discoveries:this.player.data.values.discoveries });
+      // hyperspace jump every 5
+      if(this.player.data.values.discoveries %5===0) this.jumpSector();
+    }
+    // TODO: log names/descriptions
+  }
+
+  shield(){
+    if(this.player.data.values.shield) return;
+    this.player.data.values.shield=true;
+    const circle = this.add.circle(this.player.x,this.player.y,40,0x20b2ae,0.5);
+    this.time.delayedCall(300, ()=>{ circle.destroy(); this.player.data.values.shield=false; });
+  }
+
+  playerHit(player, enemy){
+    enemy.destroy();
+    if(this.player.data.values.shield) return;
+    this.player.data.values.hull--;
+    this.events.emit('updateHud', { hull:this.player.data.values.hull });
+    if(this.player.data.values.hull<=0){ this.gameOver(); }
+  }
+
+  hitEnemy(bullet, enemy){
+    bullet.destroy();
+    enemy.setData('hp', enemy.getData('hp')-1);
+    if(enemy.getData('hp')<=0){ enemy.destroy(); this.player.data.values.discoveries++; this.events.emit('updateHud',{discoveries:this.player.data.values.discoveries}); }
+  }
+
+  jumpSector(){
+    this.seed = (this.seed*16807)%2147483647;
+    this.loadSector(this.seed);
+    this.events.emit('updateHud',{ sector:this.sector.name });
+  }
+
+  gameOver(){
+    this.scene.stop('HUD');
+    this.scene.start('Title');
+  }
+
+  togglePhoto(){
+    this.photo = !this.photo;
+    const pipes = this.game.registry.get('pipelines');
+    pipes.bloom.intensity = this.photo?1.2:0.6;
+    this.events.emit('photo', this.photo);
+  }
+
+  update(time, delta){
+    // input movement
+    const speed = 200;
+    let vx=0, vy=0;
+    if(this.cursors.left.isDown || this.keys.A.isDown) vx=-speed;
+    else if(this.cursors.right.isDown || this.keys.D.isDown) vx=speed;
+    if(this.cursors.up.isDown || this.keys.W.isDown) vy=-speed;
+    else if(this.cursors.down.isDown || this.keys.S.isDown) vy=speed;
+    if(this.pad){
+      vx = this.pad.axes[0].getValue()*speed;
+      vy = this.pad.axes[1].getValue()*speed;
+      if(this.pad.buttons[0].pressed) this.fire();
+      if(Phaser.Input.Gamepad.Configs.XBOX_ONE.LB && this.pad.buttons[4].pressed) this.shield();
+      if(this.pad.buttons[2].pressed) this.scan();
+    }
+    this.player.setVelocity(vx,vy);
+
+    // keyboard actions
+    if(Phaser.Input.Keyboard.JustDown(this.keys.SPACE)) this.fire();
+    if(Phaser.Input.Keyboard.JustDown(this.keys.E)) this.scan();
+    if(Phaser.Input.Keyboard.JustDown(this.keys.SHIFT)) this.shield();
+    if(Phaser.Input.Keyboard.JustDown(this.keys.O)) this.togglePhoto();
+    if(Phaser.Input.Keyboard.JustDown(this.keys.ESC)) this.scene.pause();
+
+    // bullets cleanup
+    this.bullets.children.iterate(b=>{ if(b.y<-50) b.destroy(); });
+
+    // encounter director
+    this.director.update(time, delta);
+  }
+}

--- a/phaser-space-explorer/src/SectorFactory.js
+++ b/phaser-space-explorer/src/SectorFactory.js
@@ -1,0 +1,48 @@
+// Simple seeded RNG
+function mulberry32(a){
+  return function(){
+    a |=0; a = a + 0x6D2B79F5 |0; let t = Math.imul(a ^ a>>>15, 1 | a);
+    t = t + Math.imul(t ^ t>>>7, 61 | t) ^ t; return ((t ^ t>>>14)>>>0)/4294967296;
+  }
+}
+
+export default function SectorFactory(seed){
+  const rand = mulberry32(seed);
+  const sector = {
+    name: 'Sector ' + seed,
+    stars: [],
+    galaxies: [],
+    nebulae: [],
+    planets: [],
+    belts: [],
+    stations: [],
+    anomalies: [],
+    tint: Phaser.Display.Color.IntegerToColor(0xFFFFFF).color,
+    ambient: 'deep',
+    encounterWeights: { scout:0.7, tank:0.2, pulsar:0.1 }
+  };
+  // stars - 3 layers
+  for(let l=0;l<3;l++){
+    const layer = [];
+    for(let i=0;i<200;i++){
+      layer.push({ x: rand()*2000-1000, y: rand()*2000-1000, depth: 0.2 + l*0.3 });
+    }
+    sector.stars.push(layer);
+  }
+  // planets
+  const planetCount = 1 + Math.floor(rand()*2);
+  for(let i=0;i<planetCount;i++){
+    sector.planets.push({ x: rand()*1600-800, y: rand()*1200-600, scale: 0.5+rand(), tint: Phaser.Display.Color.RandomRGB().color });
+  }
+  // galaxies
+  const galaxyCount = Math.floor(rand()*2);
+  for(let i=0;i<galaxyCount;i++){
+    sector.galaxies.push({ x: rand()*1800-900, y: rand()*1400-700, scale:0.6+rand()*0.5, rot: rand()*360 });
+  }
+  // nebulae
+  const nebulaCount = 1 + Math.floor(rand()*2);
+  for(let i=0;i<nebulaCount;i++){
+    sector.nebulae.push({ x: rand()*1600-800, y: rand()*1200-600, color: Phaser.Display.Color.RandomRGB().color, alpha:0.2+rand()*0.3 });
+  }
+  return sector;
+}

--- a/phaser-space-explorer/src/TitleScene.js
+++ b/phaser-space-explorer/src/TitleScene.js
@@ -1,0 +1,17 @@
+export default class TitleScene extends Phaser.Scene {
+  constructor(){ super('Title'); }
+  create(){
+    const { width, height } = this.scale;
+    const t = this.add.text(width/2, height/2 - 60, 'Deep Space Explorer', { fontSize:32, color:'#e5e7eb' }).setOrigin(0.5);
+    const s = this.add.text(width/2, height/2, 'Press Space / A to launch', { fontSize:18, color:'#a0aec0' }).setOrigin(0.5);
+
+    this.input.keyboard.once('keydown-SPACE', ()=> this.start());
+    this.input.on('pointerdown', ()=> this.start());
+
+    this.input.gamepad.once('down', (pad, button, index)=>{ if(index===0) this.start(); });
+  }
+  start(){
+    this.scene.start('Play');
+    this.scene.launch('HUD');
+  }
+}

--- a/phaser-space-explorer/src/pipelines/BloomPipeline.js
+++ b/phaser-space-explorer/src/pipelines/BloomPipeline.js
@@ -1,0 +1,32 @@
+// Very lightweight bloom post-process. Not physical; just softens and adds glow.
+export default class BloomPipeline extends Phaser.Renderer.WebGL.Pipelines.PostFXPipeline {
+  constructor(game) {
+    super({
+      game,
+      name: 'BloomPipeline',
+      fragShader: `
+      precision mediump float;
+      uniform sampler2D uMainSampler;
+      varying vec2 outTexCoord;
+      uniform float intensity;
+      uniform vec2 resolution;
+      void main(){
+        vec4 col = texture2D(uMainSampler, outTexCoord);
+        vec2 off = 1.0 / resolution;
+        vec4 sum = vec4(0.0);
+        for(int x=-1; x<=1; x++){
+          for(int y=-1; y<=1; y++){
+            sum += texture2D(uMainSampler, outTexCoord + vec2(float(x),float(y))*off);
+          }
+        }
+        gl_FragColor = col + (sum/9.0)*intensity;
+      }
+      `
+    });
+    this.intensity = 0.6;
+  }
+  onPreRender(){
+    this.set1f('intensity', this.intensity);
+    this.set2f('resolution', this.renderer.width, this.renderer.height);
+  }
+}

--- a/phaser-space-explorer/src/pipelines/VignettePipeline.js
+++ b/phaser-space-explorer/src/pipelines/VignettePipeline.js
@@ -1,0 +1,25 @@
+export default class VignettePipeline extends Phaser.Renderer.WebGL.Pipelines.PostFXPipeline {
+  constructor(game){
+    super({
+      game,
+      name: 'VignettePipeline',
+      fragShader: `
+      precision mediump float;
+      uniform sampler2D uMainSampler;
+      varying vec2 outTexCoord;
+      uniform float strength;
+      void main(){
+        vec4 color = texture2D(uMainSampler, outTexCoord);
+        float dist = distance(outTexCoord, vec2(0.5));
+        float vig = smoothstep(0.8, 0.2, dist);
+        color.rgb *= mix(1.0, vig, strength);
+        gl_FragColor = color;
+      }
+      `
+    });
+    this.strength = 0.5;
+  }
+  onPreRender(){
+    this.set1f('strength', this.strength);
+  }
+}


### PR DESCRIPTION
## Summary
- add Phaser 3 implementation of exploration-first space game with post-processing pipelines
- generate procedural sectors and enemy encounters with bloom & vignette effects
- include HUD scene, gamepad support, audio stubs, and performance knobs for density & bloom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689595d52c00832c8a583dc19377badf