### PR TITLE
docs: add live site link and game overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A modern, interactive portfolio website showcasing my projects and professional journey. Built with a focus on user experience, animations, and responsive design.
 
+Visit the live site at [heyy-prateek.vercel.app](https://heyy-prateek.vercel.app).
+
 ## 🌟 Features
 
 - **Interactive Splash Screen**: Engaging rocket animation with countdown
@@ -14,10 +16,21 @@ A modern, interactive portfolio website showcasing my projects and professional 
   - Back to top button
   - Project filtering system
 - **Starry Background**: Dynamic star field animation
-- **Project Showcase**: 
+- **Project Showcase**:
   - Filterable project categories
   - Detailed project cards with tags
   - Smooth transitions between projects
+
+## 🕹️ Deep Space Explorer Game
+
+Deep Space Explorer is a mini-game built with Phaser 3 where you pilot a ship through procedurally generated star sectors. Scan planets, fend off enemies, and jump to new regions as you make discoveries.
+
+### Game Features
+
+- **Procedural Sectors**: Dynamic starfields populated with planets and nebulae
+- **Discovery System**: Scan celestial bodies to log discoveries and trigger hyperspace jumps
+- **Combat & Defense**: Shoot enemies, raise shields, and manage limited hull integrity
+- **Flexible Controls**: Play with keyboard or gamepad, including a photo mode toggle
 
 ## 🛠️ Technologies Used
 


### PR DESCRIPTION
## Summary
- document live site hosted at heyy-prateek.vercel.app
- highlight Deep Space Explorer game and its features

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1751c0518832c8bc9c68966e12b7a